### PR TITLE
two significant fixes

### DIFF
--- a/client/src/main/java/clientModules/request/sender/RequestSender.java
+++ b/client/src/main/java/clientModules/request/sender/RequestSender.java
@@ -44,24 +44,21 @@ public class RequestSender implements RequestAble<Response, Request> {
         try {
             module.sendData(os.serialize(request));
 
-            while (true) {
+            do {
                 byte[] data = module.receiveData();
                 header = headerParser.parseHeader(data);
                 byte[] partOfResponseData = responseDataParser.extractResponseData(data);
 
                 chunks.put(header.getPacketIndex(), partOfResponseData);
 
-                if (data.length < UdpDataTransferUtilities.PACKET_SIZE.getPacketSizeValue()) {
-                    break;
-                }
-            }
+            } while (header.getPacketIndex() != -1);
 
             byte[] responseData = new ResponseAssembler().combineResponseParts(chunks);
             response = new ResponseReader().readResponse(responseData);
         } catch (IllegalArgumentException e) {
-            System.out.println("Unexpected error: Response part is missing");
+            System.out.println("Response part is missing");
         } catch (ClassNotFoundException e) {
-            System.out.println("Unexpected error: Could not find response class");
+            System.out.println("Could not find response class");
         }
 
         return response;

--- a/client/src/main/java/clientModules/response/receivers/CommandsReceiver.java
+++ b/client/src/main/java/clientModules/response/receivers/CommandsReceiver.java
@@ -31,7 +31,7 @@ public class CommandsReceiver {
             new ClientCommandsHandler().handleResponse(new CommandsRequestSender().sendRequest(module, new ClientCommandsRequest()));
             return true;
         } catch (NullPointerException e) {
-            throw new IOException("Unexpected error: Empty response received");
+            throw new IOException("Empty response received");
         }
     }
 

--- a/client/src/main/java/clientModules/response/receivers/ExecutionResultReceiver.java
+++ b/client/src/main/java/clientModules/response/receivers/ExecutionResultReceiver.java
@@ -11,6 +11,7 @@ import requests.CommandExecutionRequest;
 import response.responses.ExecutionResultResponse;
 
 import java.io.IOException;
+import java.io.StreamCorruptedException;
 
 /**
  * A class that represents the command execution result receiver.
@@ -37,10 +38,10 @@ public class ExecutionResultReceiver implements CommandReceiver {
             new ExecutionResultHandler().handleResponse(resultResponses);
 
             CommandHandler.getMissedCommands().remove(cmd, args);
+        } catch (StreamCorruptedException | ServerUnavailableException | ResponseTimeoutException e) {
+            CommandHandler.getMissedCommands().put(cmd, args);
         } catch (IOException e) {
             System.out.println("Something went wrong during I/O operations");
-        } catch (ServerUnavailableException | ResponseTimeoutException e) {
-            CommandHandler.getMissedCommands().put(cmd, args);
         } catch (NullPointerException e) {
             System.out.println("Unexpected error: Empty response received");
         }

--- a/client/src/main/java/clientModules/response/receivers/ExitCommandReceiver.java
+++ b/client/src/main/java/clientModules/response/receivers/ExitCommandReceiver.java
@@ -11,6 +11,7 @@ import requests.CommandExecutionRequest;
 import response.responses.ExecutionResultResponse;
 
 import java.io.IOException;
+import java.io.StreamCorruptedException;
 import java.util.Scanner;
 
 /**
@@ -50,10 +51,10 @@ public class ExitCommandReceiver implements CommandReceiver {
             new ExitCommandHandler().handleResponse(resultResponses);
 
             CommandHandler.getMissedCommands().remove(cmd, args);
+        } catch (StreamCorruptedException | ServerUnavailableException | ResponseTimeoutException e) {
+            CommandHandler.getMissedCommands().put(cmd, args);
         } catch (IOException e) {
             System.out.println("Something went wrong during I/O operations");
-        } catch (ServerUnavailableException | ResponseTimeoutException e) {
-            CommandHandler.getMissedCommands().put(cmd, args);
         } catch (NullPointerException e) {
             System.out.println("Unexpected error: Empty response received");
         }

--- a/client/src/main/java/clientModules/response/receivers/PersonCommandResultReceiver.java
+++ b/client/src/main/java/clientModules/response/receivers/PersonCommandResultReceiver.java
@@ -13,6 +13,7 @@ import requests.SingleArgumentCommandExecutionRequest;
 import response.responses.ExecutionResultResponse;
 
 import java.io.IOException;
+import java.io.StreamCorruptedException;
 
 /**
  * A class that represents the person single argument command execution result receiver.
@@ -40,10 +41,10 @@ public class PersonCommandResultReceiver implements CommandReceiver {
             new ExecutionResultHandler().handleResponse(resultResponses);
 
             CommandHandler.getMissedCommands().remove(cmd, args);
+        } catch (StreamCorruptedException | ServerUnavailableException | ResponseTimeoutException e) {
+            CommandHandler.getMissedCommands().put(cmd, args);
         } catch (IOException e) {
             System.out.println("Something went wrong during I/O operations");
-        } catch (ServerUnavailableException | ResponseTimeoutException e) {
-            CommandHandler.getMissedCommands().put(cmd, args);
         } catch (NullPointerException e) {
             System.out.println("Unexpected error: Empty response received");
         }

--- a/client/src/main/java/clientModules/response/receivers/ScriptCommandReceiver.java
+++ b/client/src/main/java/clientModules/response/receivers/ScriptCommandReceiver.java
@@ -12,10 +12,7 @@ import org.apache.commons.io.IOUtils;
 import requests.CommandExecutionRequest;
 import response.responses.ExecutionResultResponse;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 
@@ -59,7 +56,7 @@ public class ScriptCommandReceiver implements CommandReceiver {
             try {
                 new ExecutionResultHandler().handleResponse(new CommandExecutionRequestSender()
                         .sendRequest(module, new CommandExecutionRequest(cmd, args)));
-            } catch (ServerUnavailableException | ResponseTimeoutException e) {
+            } catch (StreamCorruptedException | ServerUnavailableException | ResponseTimeoutException e) {
                 CommandHandler.getMissedCommands().put(cmd, args);
                 return;
             } catch (NullPointerException e) {

--- a/client/src/main/java/utils/ResponseAssembler.java
+++ b/client/src/main/java/utils/ResponseAssembler.java
@@ -25,14 +25,21 @@ public class ResponseAssembler {
         byte[] combinedResponse = new byte[totalSize];
 
         int offset = 0;
-        for (int i = 0; i < responseParts.size(); i++) {
-            byte[] part = responseParts.get(i);
-            if (part != null) {
-                System.arraycopy(part, 0, combinedResponse, offset, part.length);
-                offset += part.length;
-            } else {
-                throw new IllegalArgumentException("Response part is missing for index: " + i);
+        if (responseParts.size() > 1) {
+            for (int i = 0; i < responseParts.size() - 1; i++) {
+                byte[] part = responseParts.get(i);
+                if (part != null) {
+                    System.arraycopy(part, 0, combinedResponse, offset, part.length);
+                    offset += part.length;
+                } else {
+                    throw new IllegalArgumentException("Response part is missing for index " + i);
+                }
             }
+        }
+
+        byte[] lastPart = responseParts.get(-1);
+        if (lastPart != null) {
+            System.arraycopy(lastPart, 0, combinedResponse, offset, lastPart.length);
         }
 
         return combinedResponse;

--- a/client/src/main/java/utils/ResponseDataParser.java
+++ b/client/src/main/java/utils/ResponseDataParser.java
@@ -1,5 +1,7 @@
 package utils;
 
+import utility.UdpDataTransferUtilities;
+
 /**
  * A class that represents response data parser.
  */
@@ -17,6 +19,11 @@ public class ResponseDataParser {
     public byte[] extractResponseData(byte[] data) {
         int headerSize = data[0];
         int responseDataSize = data.length - headerSize - 1;
+
+        if (responseDataSize <= 0) {
+            return new byte[0];
+        }
+
         byte[] responseData = new byte[responseDataSize];
         System.arraycopy(data, headerSize + 1, responseData, 0, responseDataSize);
 

--- a/server/Person.yaml
+++ b/server/Person.yaml
@@ -569,3 +569,14 @@
   passportID: "21345678"
   hairColor: "RED"
   location: null
+- id: 43
+  name: "test 3 "
+  coordinates:
+    x: 435
+    "y": 8767
+  creationDate: "2023-05-25T11:51:35.190+00:00"
+  height: 4
+  birthday: "2005-10-11T12:26:30.000+00:00"
+  passportID: "programming on java is fucking hell"
+  hairColor: "BLACK"
+  location: null

--- a/server/src/main/java/serverModules/response/sender/ResponseSender.java
+++ b/server/src/main/java/serverModules/response/sender/ResponseSender.java
@@ -29,7 +29,7 @@ public class ResponseSender implements ResponseAble<Response> {
      */
 
     @Override
-    public void sendResponse(ConnectionModule module, CallerBack callerBack, Response response) {
+    public void sendResponse(ConnectionModule module, CallerBack callerBack, Response response) throws IllegalArgumentException {
         if (response != null) {
             ObjectSerializer os = new ObjectSerializer();
             final InetAddress address = callerBack.getAddress();
@@ -45,6 +45,10 @@ public class ResponseSender implements ResponseAble<Response> {
                     byte[] headerData = os.serialize(header);
                     int headerDataLength = headerData.length;
 
+                    if (headerDataLength >= maxPacketSize - 1) {
+                        throw new IllegalArgumentException("Header data size is larger than max packet size");
+                    }
+
                     int freeSpace = maxPacketSize - headerDataLength - 1;
                     int remainingData = data.length - offset;
                     int length = Math.min(freeSpace, remainingData);
@@ -59,6 +63,20 @@ public class ResponseSender implements ResponseAble<Response> {
                     packetIndex++;
                     offset += length;
                 }
+
+                FragmentHeader header = new FragmentHeader(-1);
+                byte[] headerData = os.serialize(header);
+                int headerDataLength = headerData.length;
+
+                if (headerDataLength >= maxPacketSize - 1) {
+                    throw new IllegalArgumentException("Header data size is larger than max packet size");
+                }
+
+                byte[] noDataNotification = new byte[headerDataLength + 1];
+                noDataNotification[0] = (byte) headerDataLength;
+                System.arraycopy(headerData, 0, noDataNotification, 1, headerDataLength);
+
+                module.sendData(noDataNotification, address, port);
             } catch (Exception e) {
                 logger.fatal("Something went wrong during I/O operations", e);
             }

--- a/server/src/main/java/serverModules/response/sender/ResponseSender.java
+++ b/server/src/main/java/serverModules/response/sender/ResponseSender.java
@@ -45,8 +45,9 @@ public class ResponseSender implements ResponseAble<Response> {
                     byte[] headerData = os.serialize(header);
                     int headerDataLength = headerData.length;
 
+                    int freeSpace = maxPacketSize - headerDataLength - 1;
                     int remainingData = data.length - offset;
-                    int length = Math.min(maxPacketSize - headerDataLength - 1, remainingData);
+                    int length = Math.min(freeSpace, remainingData);
 
                     byte[] packet = new byte[length + headerDataLength + 1];
                     packet[0] = (byte) headerDataLength;


### PR DESCRIPTION
added Stream Corrupted Exception in some try catch blocks. updated receiving packets on client. now it waits till the -1 packet is received. if the -1 packet has no data but only header, then skips it while assembling. otherwise adds its data in the end no matter if its first and only response or not.